### PR TITLE
Fix gsettings

### DIFF
--- a/README
+++ b/README
@@ -29,12 +29,19 @@ sudo dnf install linux-gpib-firmware
 
 To install
         $ ./autogen.sh
-        $ ./configure
-        $ make
-        $ sudo make check
+        $ cd build/
+        $ ../configure
+        $ make all
         $ sudo make install
+To run:
+        
+        $ /usr/local/bin/HPGLplotter
 
-To uninstall
+To uninstall:
+        
         $ sudo make uninstall
 
+To see logs:
+
+        journalctl -t HPGLplotter -f
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ If problems are encountered, first confirm that correct GPIB communication is oc
 
 **Note** that the GPIB interface on the Linux computer must be able to act as a simple listener / talker. Some devices (notably the **Agilent 82357A/B**) can only act as system controllers and will not work with this application. (the National Instruments GPIB-USB-HS does work as it does not have this restriction)
 
-The program requires the `gtk4` library, on the Linux system, to be version 4.10 or later. To check, use: 
-`$ gtk4-launch --version`
+The program requires the `gtk4` library, on the Linux system, to be version 4.10 or later. The build system will automatically check for this requirement during configuration. To manually check your GTK4 version, use: 
+`$ pkg-config --modversion gtk4`
 
 The program has been tested with the HP8753C Network Analyzer, HP8595E Spectrum Analyzer, HP8568B Spectrum Analyzer and the HP54100 oscilloscope. <em>(If you use it with other instruments, please report your experience)</em>
 

--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,7 @@ fi
 YELP_HELP_INIT
 
 PKG_CHECK_MODULES([GLIB], [glib-2.0])
-PKG_CHECK_MODULES([GTK4], [gtk4])
+PKG_CHECK_MODULES([GTK4], [gtk4 >= 4.10])
 
 # files required for building
 

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,9 @@ m4_include([config_m4/versioning.m4])
 # libgpib
 AC_CHECK_LIB(gpib,ibask,,AC_MSG_ERROR([Please install Linux GPIB driver before continuing.]))
 
+# libgs (Ghostscript)
+AC_CHECK_LIB(gs,gsapi_new_instance,,AC_MSG_ERROR([Please install Ghostscript development library (libgs-dev on Debian type systems).]))
+
 # libsystemd
 # AC_CHECK_LIB(systemd,sd_journal_print,,AC_MSG_ERROR([Please install systemd library (libsystemd-dev on Debian type systems).]))
 

--- a/data/gsettings/us.heterodyne.hpgl-plotter.gschema.xml
+++ b/data/gsettings/us.heterodyne.hpgl-plotter.gschema.xml
@@ -51,11 +51,32 @@
         GPIB PID of the plotter we are emulating.
       </description>
     </key>
+    <key name="hpgl-end-period" type="d">
+      <default>0.7</default>
+      <summary>HPGL end period</summary>
+      <description>
+        Period after last HPGL command to assume plot has ended.
+      </description>
+    </key>
     <key name="gpib-use-controller-index" type="b">
       <default>true</default>
       <summary>Selection of whether to use the index or name of the GPIB controller</summary>
       <description>
         Selection of whether to use the index or name of the GPIB controller
+      </description>
+    </key>
+    <key name="gpib-initial-listener" type="b">
+      <default>false</default>
+      <summary>Force GPIB as listenter on initialization</summary>
+      <description>
+        Selection of whether force GPIB as listenter on initialization
+      </description>
+    </key>
+    <key name="gpib-do-not-enable-system" type="b">
+      <default>false</default>
+      <summary>Do not enable GPIB as system controller</summary>
+      <description>
+        Do not switch the GPIB interface to system controller if there is another controller on the bus
       </description>
     </key>
     <key name="auto-clear" type="b">


### PR DESCRIPTION
Hi, I fixed the issues with gsettings that were making the app crash on fresh installs, and added a couple of quality-of-life improvements

- fixes gconfig default values
- updates README file that was out of sync with README.md (maybe README should be deleted?)
- declared requirement of GTK 4.10+ on configure.ac, so it fails even before trying to build
- declared requirement of libgs on configure.ac

closes #3 