### PR TITLE
Round fractional parameters

### DIFF
--- a/src/parseHPGL.c
+++ b/src/parseHPGL.c
@@ -243,15 +243,15 @@ addLinePoints( tGlobal *pGlobal, gchar *sXYpoints, guint *pHPGLserialCount, gboo
     bMorePoints = *pNextChar != 0;
 
     while ( bMorePoints ) {
-        gint64 x = g_ascii_strtoll( pNextChar, &pNextChar, 10 );
+        gdouble x = g_ascii_strtod( pNextChar, &pNextChar );
         while( g_ascii_isspace(*pNextChar) || *pNextChar == ',' )
             pNextChar++;
-        gint64 y = g_ascii_strtoll( pNextChar, &pNextChar, 10 );
+        gdouble y = g_ascii_strtod( pNextChar, &pNextChar );
         while( g_ascii_isspace(*pNextChar) || *pNextChar == ',' )
             pNextChar++;
 
-        p.x = (gint32)x;
-        p.y = (gint32)y;
+        p.x = (gint32)round(x); 
+        p.y = (gint32)round(y); 
 
         append( &pGlobal->plotHPGL, pHPGLserialCount,
                 bAbsolute ? CHPGL_MOVE : CHPGL_RMOVE,  &p, sizeof(tCoord)  );


### PR DESCRIPTION
Some instruments (like R&S UPL) emit fractional values, for example in `PA` commands.

Fractional parameters not handled, causing the function to loop infinitely and then crashes. 

This PR rounds fractional values to integers. [This HP document](https://blog.nicholashanna.net/wp-content/uploads/2014/09/HPGL-Programmers-Manual.pdf) (Page 20) shows that even for integer parameters, decimals are generally truncated/rounded.

It might also be nice to support plotting with decimals - page 28 also shows which HP plotters suport both integer and decimal plotting for `PA`.

Example plot: [demo.HPGL.txt](https://github.com/user-attachments/files/23124878/demo.HPGL.txt)

