### PR TITLE
Fix UB when handling `LT` with no parameters

### DIFF
--- a/src/parseHPGL.c
+++ b/src/parseHPGL.c
@@ -392,8 +392,10 @@ parseHPGLcmd( guint16 HPGLcmd, gchar *sHPGLargs, tGlobal *pGlobal ) {
 		break;
 
 	case HPGL_LINE_TYPE:	// LT
-		sscanf(sHPGLargs, "%"SCNu8, &lineType);
-		append( &pGlobal->plotHPGL, &HPGLserialCount, CHPGL_LINETYPE,  &lineType, sizeof( guint8 )  );
+		if (sscanf(sHPGLargs, "%"SCNu8, &lineType) != 1) {
+			lineType = 0;
+		}
+		append( &pGlobal->plotHPGL, &HPGLserialCount, CHPGL_LINETYPE,  &lineType, sizeof(guint8) );
 		break;
 
 	case HPGL_SELECT_PEN:	// SP


### PR DESCRIPTION
`LT;` with no parameters is a valid command, but currently causes undefined behaviour. This should reset the line style to solid.

This PR fixes it by checking the return value from `sscanf`. This fix should probably also be applied to other commands that can take zero parameters.

See same example in my other issue.
